### PR TITLE
Add tests for loading utilities

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,23 @@
+import pytest
+from streamlit_app import load_models, load_sample_data
+
+
+def test_load_models_returns_all_models():
+    models = load_models()
+    assert isinstance(models, dict)
+    expected = {"Decision Tree", "Random Forest", "Naive Bayes", "K-Nearest Neighbors"}
+    assert set(models.keys()) == expected
+
+
+def test_load_sample_data_matches_model_features():
+    models = load_models()
+    df = load_sample_data()
+    features = list(df.columns)
+    for name, model in models.items():
+        if hasattr(model, "feature_names_in_"):
+            assert list(model.feature_names_in_) == features
+        elif hasattr(model, "n_features_in_"):
+            assert model.n_features_in_ == len(features)
+        else:
+            pytest.fail(f"Model {name} does not expose feature names")
+


### PR DESCRIPTION
## Summary
- create a test suite for `load_models` and `load_sample_data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit_app')*

------
https://chatgpt.com/codex/tasks/task_e_68859e0602708327a09d1c713b90d772