### PR TITLE
docs: add references section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Feel free to open an issue or submit a pull request to enhance features, improve
 
 ## 📜 License
 This project is licensed under the MIT License.
+
+## 📚 References
+- [LIME Documentation](https://marcotcr.github.io/lime/)
+- [SHAP Documentation](https://shap.readthedocs.io/)


### PR DESCRIPTION
## Summary
- add references to LIME and SHAP docs in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit_app')*


------
https://chatgpt.com/codex/tasks/task_e_68a79cee626c83279967d7d6a531d277