### PR TITLE
Add psychedelic theme and animations to UI

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -107,12 +107,31 @@ else:  # LIME
     selected_lime_model_name = st.sidebar.selectbox("Model for LIME:", list(models.keys()))
 
 st.sidebar.header("Appearance")
-theme_choice = st.sidebar.selectbox("Theme", ["Light", "Dark"])
+theme_choice = st.sidebar.selectbox("Theme", ["Light", "Dark", "Psychedelic"])
 if theme_choice == "Dark":
     st.markdown(
         """
         <style>
         .stApp {background-color: #0e1117; color: white;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+elif theme_choice == "Psychedelic":
+    st.markdown(
+        """
+        <style>
+        @keyframes psychedelic-bg {
+            0% {background-color: #ff00ff;}
+            25% {background-color: #00ffff;}
+            50% {background-color: #ffff00;}
+            75% {background-color: #ff6600;}
+            100% {background-color: #ff00ff;}
+        }
+        .stApp {
+            animation: psychedelic-bg 10s infinite;
+            color: white;
+        }
         </style>
         """,
         unsafe_allow_html=True,
@@ -295,6 +314,10 @@ with tab1:
         if confidences:
             vote = "Subscribed" if sum(predictions) >= len(predictions)/2 else "Not Subscribed"
             st.markdown(f"**Ensemble Vote:** `{vote}`")
+            if vote == "Subscribed":
+                st.balloons()
+            else:
+                st.snow()
             st.markdown(f"**Avg Confidence:** `{np.mean(confidences):.2f}`")
             fig, ax = plt.subplots()
             sns.barplot(x=selected_models, y=confidences, ax=ax)


### PR DESCRIPTION
## Summary
- Introduce new **Psychedelic** theme with animated background colors.
- Celebrate predictions with balloons for positive outcomes and snow for negative ones.

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3a0f134883279fbd84427f030c79