### PR TITLE
Handle non-numeric values during schema validation

### DIFF
--- a/app_utils/schema.py
+++ b/app_utils/schema.py
@@ -66,10 +66,17 @@ def validate_schema(df: pd.DataFrame, required_columns: Iterable[str]) -> Valida
                 if pd.isna(value):
                     messages.append(f"{col} is missing")
                     continue
-                if lower is not None and value < lower:
-                    messages.append(f"{col}={value} below minimum {lower}")
-                if upper is not None and value > upper:
-                    messages.append(f"{col}={value} above maximum {upper}")
+
+                try:
+                    numeric_value = float(value)
+                except (TypeError, ValueError):
+                    messages.append(f"{col} must be numeric, got {value}")
+                    continue
+
+                if lower is not None and numeric_value < lower:
+                    messages.append(f"{col}={numeric_value} below minimum {lower}")
+                if upper is not None and numeric_value > upper:
+                    messages.append(f"{col}={numeric_value} above maximum {upper}")
             for indicator in BINARY_INDICATORS:
                 if indicator in df.columns:
                     value = row.get(indicator)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,6 +113,16 @@ def test_validate_schema_captures_numeric_limits_and_missing_values():
     assert "campaign is missing" in report.row_errors[1]
 
 
+def test_validate_schema_reports_non_numeric_values_instead_of_erroring():
+    df = load_sample_data().head(1).copy()
+    df.loc[0, "age"] = "thirty"
+
+    report = validate_schema(df, df.columns)
+
+    assert not report.is_valid
+    assert "age must be numeric" in report.row_errors[0]
+
+
 def test_compute_group_metrics_handles_zero_reference_rate():
     df = pd.DataFrame({"marital_single": [1, 0, 0]})
     preds = np.array([1, 0, 0])


### PR DESCRIPTION
## Summary
- add numeric coercion checks in schema validation to prevent TypeErrors
- report non-numeric inputs as validation errors instead of crashing
- add regression test for string values in numeric columns

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693243395a248327ba98eb7c33abbfa9)